### PR TITLE
Reformatted the delete scene buttons

### DIFF
--- a/src/client/src/views/Scenes.js
+++ b/src/client/src/views/Scenes.js
@@ -15,22 +15,21 @@ module.exports = {
       m('h2', 'List of scenes'),
       m('.scene-list', Scene.getScenes()
         .map(function(scene) {
-          return m('a.scene-list-item', {
-            onclick: function() {
-              m.route.set(`/edit-scene/${scene.id}`, {
-                captions: scene.captions
-              })
-            }
-          }, `Scene ${scene.id}`)
-        })),
-        m('.scene-list', Scene.getScenes()
-          .map(function(scene) {
-            return m('a.scene-list-item', {
-              onclick: function() {
-                Scene.deleteScene(scene.id)
+	  return m('div.scene-list-item', [
+	    m('a', {
+	      onclick: function() {
+		m.route.set(`/edit-scene/${scene.id}`, {
+		  captions: scene.captions
+		})
               }
-            }, `Delete Scene ${scene.id}`)
-          })),
+            }, `Scene ${scene.id}`),
+	    m('button.delete-scene-button', {
+	      onclick: function() {
+		Scene.deleteScene(scene.id)
+	      }
+	    }, 'Delete')
+	  ])
+        })),
           
       m('button.delete-all-scenes', {
         onclick: function() {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -13,3 +13,7 @@
   padding: 8px 15px;
   text-decoration: none;
 }
+
+.delete-scene-button {
+  margin-left: 2em;
+}

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -5,7 +5,7 @@
 }
 
 .scene-list-item, .caption-list-item {
-  background: #fafafa;
+  background: #fafafa; /* light grey */
   border: 1px solid #ddd;
   color: #333;
   display: block;
@@ -15,11 +15,11 @@
 }
 
 .scene-list-item:hover, .caption-list-item:hover {
-  background: #cccccc;
+  background: #cccccc; /* slightly darker grey to emphasize selection */
 }
 
-.scene-list-item a, caption-list-item a {
-  color: #0000EE;
+.scene-list-item a, .caption-list-item a {
+  color: #0000EE; /* blue color for links */
   text-decoration: underline;
 }
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -14,6 +14,19 @@
   text-decoration: none;
 }
 
+.scene-list-item:hover, .caption-list-item:hover {
+  background: #cccccc;
+}
+
+.scene-list-item a, caption-list-item a {
+  color: #0000EE;
+  text-decoration: underline;
+}
+
+a:hover {
+  cursor: pointer;
+}
+
 .delete-scene-button {
   margin-left: 2em;
 }


### PR DESCRIPTION
Reformatted the delete scene buttons so now it is on the same line as the scene it is deleting. Also made minor CSS tweaks.

I didn't like how the delete buttons were in a separate list below the scene list items. I think having the delete buttons next to the scene list items is more intuitive, and is also how the delete buttons were displayed in the UI wireframe.