### PR TITLE
Per 208, 206, 216

### DIFF
--- a/src/client/src/index.js
+++ b/src/client/src/index.js
@@ -19,7 +19,7 @@ const CaptionForm = require('./views/CaptionForm')
 m.route(document.body, '/start', {
   '/start': Start,
   '/scenes': Scenes,
-  '/scenes/scene-:id': {
+  '/scenes/scene-:sceneId': {
     render: function(vnode) {
       return m(SceneForm, vnode.attrs)
     }

--- a/src/client/src/index.js
+++ b/src/client/src/index.js
@@ -19,12 +19,12 @@ const CaptionForm = require('./views/CaptionForm')
 m.route(document.body, '/start', {
   '/start': Start,
   '/scenes': Scenes,
-  '/edit-scene/:id': {
+  '/scenes/scene-:id': {
     render: function(vnode) {
       return m(SceneForm, vnode.attrs)
     }
   },
-  '/edit-caption/:id': {
+  '/scenes/scene-:sceneId/caption-:captionId': {
     render: function(vnode) {
       return m(CaptionForm, vnode.attrs)
     }

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -92,9 +92,33 @@ const Scene = {
   current: null,
 
   // self-explanatory. Sets the currentScene property to the scene corresponding to the sceneId
-  setCurrent: function(sceneId) {
+  setCurrentScene: function(sceneId) {
     const list = Scene.getScenes()
     Scene.current = list[sceneId]
+  },
+
+  currentCaption: null,
+
+  setCurrentCaption: function(captionId) {
+    Scene.currentCaption = Scene.current.captions[captionId]
+  },
+
+  // saves the current caption with its new name to localStorage
+  saveCaptionName: function() {
+    const list = Scene.getScenes()
+
+    list[Scene.current.id-1].captions[Scene.currentCaption.id-1].name = Scene.currentCaption.name
+
+    localStorage.setItem('scene-list', JSON.stringify(list))
+  },
+
+  // saves the current caption with its new text to localStorage
+  saveCaptionText: function() {
+    const list = Scene.getScenes()
+
+    list[Scene.current.id-1].captions[Scene.currentCaption.id-1].text = Scene.currentCaption.text
+
+    localStorage.setItem('scene-list', JSON.stringify(list))
   }
 }
 

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -57,7 +57,7 @@ const Scene = {
     const list = Scene.getScenes()
 
     // update the current scene in the scene list 
-    list[Scene.current.id-1].captions = Scene.current.captions
+    list[Scene.currentScene.id-1].captions = Scene.currentScene.captions
 
     localStorage.setItem('scene-list', JSON.stringify(list))
   },
@@ -67,7 +67,7 @@ const Scene = {
     const list = Scene.getScenes()
 
     // update the current scene in the scene list 
-    list[Scene.current.id-1].name = Scene.current.name
+    list[Scene.currentScene.id-1].name = Scene.currentScene.name
 
     localStorage.setItem('scene-list', JSON.stringify(list))
   },
@@ -77,37 +77,37 @@ const Scene = {
     const list = Scene.getScenes()
 
     // this is a check to make sure the value entered into start is a number
-    const start_check = Number(Scene.current.start)
+    const start_check = Number(Scene.currentScene.start)
     if (isNaN(start_check)) {
-      Scene.current.start = ``
+      Scene.currentScene.start = ``
     }
 
     // update the current scenes start in the scene list 
-    list[Scene.current.id-1].start = Scene.current.start
+    list[Scene.currentScene.id-1].start = Scene.currentScene.start
 
     localStorage.setItem('scene-list', JSON.stringify(list))
   },
 
   // this is useful to have as a way to manage a scene using global state
-  current: null,
+  currentScene: null,
 
   // self-explanatory. Sets the currentScene property to the scene corresponding to the sceneId
   setCurrentScene: function(sceneId) {
     const list = Scene.getScenes()
-    Scene.current = list[sceneId]
+    Scene.currentScene = list[sceneId]
   },
 
   currentCaption: null,
 
   setCurrentCaption: function(captionId) {
-    Scene.currentCaption = Scene.current.captions[captionId]
+    Scene.currentCaption = Scene.currentScene.captions[captionId]
   },
 
   // saves the current caption with its new name to localStorage
   saveCaptionName: function() {
     const list = Scene.getScenes()
 
-    list[Scene.current.id-1].captions[Scene.currentCaption.id-1].name = Scene.currentCaption.name
+    list[Scene.currentScene.id-1].captions[Scene.currentCaption.id-1].name = Scene.currentCaption.name
 
     localStorage.setItem('scene-list', JSON.stringify(list))
   },
@@ -116,9 +116,31 @@ const Scene = {
   saveCaptionText: function() {
     const list = Scene.getScenes()
 
-    list[Scene.current.id-1].captions[Scene.currentCaption.id-1].text = Scene.currentCaption.text
+    list[Scene.currentScene.id-1].captions[Scene.currentCaption.id-1].text = Scene.currentCaption.text
 
     localStorage.setItem('scene-list', JSON.stringify(list))
+  },
+
+  deleteCaption: function(captionId) {
+    // look for the caption
+    const indexToRemove = Scene.currentScene.captions.findIndex(function(caption) {
+      return caption.id === captionId
+    })
+
+    // no caption was found that matches captionId
+    if (captionId === -1) {
+      console.log('Cannot find the caption you are trying to delete.')
+      return
+    }
+
+    // we found the caption, so now we remove it
+    const list = Scene.getScenes()
+    list[Scene.currentScene.id-1].captions.splice(indexToRemove, 1)
+    
+    localStorage.setItem('scene-list', JSON.stringify(list))
+
+    // also remove it from currentScene
+    Scene.currentScene.captions.splice(indexToRemove, 1)
   }
 }
 

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -141,6 +141,11 @@ const Scene = {
 
     // also remove it from currentScene
     Scene.currentScene.captions.splice(indexToRemove, 1)
+
+    // loop and fix id numbers
+    for (var i = 0; i < Scene.currentScene.captions.length; i++) {
+      Scene.currentScene.captions[i].id = i + 1
+    }
   }
 }
 

--- a/src/client/src/tests/CaptionForm.js
+++ b/src/client/src/tests/CaptionForm.js
@@ -1,0 +1,35 @@
+// This is the test file for the CaptionForm view
+
+const mq = require('mithril-query')
+const o = require('ospec')
+
+const CaptionForm = require('../views/CaptionForm.js')
+const Scene = require('../models/Scene.js')
+
+o.spec('CaptionForm', function() {
+  o('things are working', function() {
+
+    // before we do anything we need to initialize the data model
+    Scene.initialize()
+
+    // also passing in the ids that the view expects as a route param
+    var out = mq(CaptionForm, {sceneId: 1, captionId: 1})
+
+    // here we are simply checking if it correctly renders the text we expected
+    o(out.should.contain('Caption 1')).equals(true)
+
+    // make sure that change name form changes the name in the view
+    out.setValue('.new-name-input', 'new name') // trigger an input in the input form
+    o(out.should.not.contain('Caption 1')).equals(true)
+    o(out.should.contain('new name')).equals(true)
+    
+    // make sure that change name form actually changes the name in the data model
+    out.trigger('.save-changes-form', 'onsubmit', {preventDefault: () => {}}) // trigger a submit event on the form
+    o(Scene.currentScene.captions.find(caption => caption.name === 'new name') !== undefined).equals(true)
+
+    // make sure that the text input changes the text
+    out.setValue('.new-caption-text-input', 'hello') // trigger an input in the input form
+    out.trigger('.save-changes-form', 'onsubmit', {preventDefault: () => {}}) // trigger a submit event on the form
+    o(Scene.currentScene.captions.find(caption => caption.text === 'hello') !== undefined).equals(true)
+  })
+})

--- a/src/client/src/tests/SceneForm.js
+++ b/src/client/src/tests/SceneForm.js
@@ -15,7 +15,7 @@ o.spec('SceneForm', function() {
     // render the SceneForm view mithril-query
     // also passing in id as attrs because this view expects id as a route param
     // note this test will have to change if we ever get rid of the default scene in Scene.initialize
-    var out = mq(SceneForm, {id: 1})
+    var out = mq(SceneForm, {sceneId: 1})
 
     // here we are simply checking if it correctly renders the text we expected
     o(out.should.contain('List of captions')).equals(true)
@@ -38,7 +38,7 @@ o.spec('SceneForm', function() {
 
     // testing the delete caption function
     Scene.deleteCaption(2) // use the scene deleteFunction to delete a scene
-    out = mq(SceneForm, {id: 1}) // rerender the scenes view
+    out = mq(SceneForm, {sceneId: 1}) // rerender the scenes view
     o(out.should.not.contain('Caption 2')).equals(true) // there should only be 2 scenes to end with
 
     // make sure that adding a negative number has the desired results

--- a/src/client/src/tests/SceneForm.js
+++ b/src/client/src/tests/SceneForm.js
@@ -36,6 +36,11 @@ o.spec('SceneForm', function() {
     out.click('.add-caption')
     o(out.should.contain('Caption 2')).equals(true)
 
+    // testing the delete caption function
+    Scene.deleteCaption(2) // use the scene deleteFunction to delete a scene
+    out = mq(SceneForm, {id: 1}) // rerender the scenes view
+    o(out.should.not.contain('Caption 2')).equals(true) // there should only be 2 scenes to end with
+
     // make sure that adding a negative number has the desired results
     out.setValue('.new-start-input', `-1`) // trigger an input in the input form
     out.trigger('.save-changes-form', 'onsubmit', {preventDefault: () => {}}) // trigger a submit event on the form

--- a/src/client/src/views/CaptionForm.js
+++ b/src/client/src/views/CaptionForm.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   view: function(vnode) {
     return m('', [
-      m('h1', Scene.currentCaption.name ? Scene.currentCaption.name : `Caption ${vnode.attrs.captionId}`),
+      m('h1', Scene.currentCaption.name ? Scene.currentCaption.name : `Caption ${Scene.currentCaption.id}`),
       m('form.save-changes-form', {
         onsubmit: function(e) {
           e.preventDefault()

--- a/src/client/src/views/CaptionForm.js
+++ b/src/client/src/views/CaptionForm.js
@@ -1,11 +1,43 @@
 // This is the caption editor page, for filling in the details of a particular caption string
 
 const m = require('mithril')
+const Scene = require('../models/Scene')
 
 module.exports = {
+  oninit: function(vnode) {
+    // first set the current Scene, then set the current caption.
+    Scene.setCurrentScene(vnode.attrs.sceneId - 1)
+    Scene.setCurrentCaption(vnode.attrs.captionId - 1)
+  },
   view: function(vnode) {
     return m('', [
-      m('h1', `Caption ${vnode.attrs.id}`),
+      m('h1', Scene.currentCaption.name ? Scene.currentCaption.name : `Caption ${vnode.attrs.captionId}`),
+      m('form.save-changes-form', {
+        onsubmit: function(e) {
+          e.preventDefault()
+          Scene.saveCaptionName()
+          Scene.saveCaptionText()
+        }
+      }, [
+        m("input.new-name-input[type=text]", {
+          oninput: function (e) {
+            Scene.currentCaption.name = e.target.value
+          },
+            value: Scene.currentCaption.name ? Scene.currentCaption.name : `Caption ${Scene.currentCaption.id}`
+        }),
+        m('h2', `Text`),
+        m("input.new-caption-text-input[type=text]", {
+          oninput: function (e) {
+            Scene.currentCaption.text = e.target.value
+          },
+          value: Scene.currentCaption.text ? Scene.currentCaption.text : ``
+        }),
+        m('h5', ``),
+        m("button.save-changes-button[type=submit]", 'Save all changes'),
+      ])
     ])
   }
 }
+
+
+

--- a/src/client/src/views/SceneForm.js
+++ b/src/client/src/views/SceneForm.js
@@ -9,13 +9,13 @@ module.exports = {
     Scene.setCurrentScene(vnode.attrs.id - 1)
   },
   view: function(vnode) {
-    const captions = Scene.current.captions
-
+    const captions = Scene.currentScene.captions
+    
     return m('', [
       m(m.route.Link, {
         href: '/scenes',
       }, 'Back To Scene List'),
-      m('h1', Scene.current.name ? Scene.current.name : `Scene ${Scene.current.id}`),
+      m('h1', Scene.currentScene.name ? Scene.currentScene.name : `Scene ${Scene.currentScene.id}`),
       m('form.save-changes-form', {
         onsubmit: function(e) {
           e.preventDefault()
@@ -25,34 +25,46 @@ module.exports = {
       }, [
         m("input.new-name-input[type=text]", {
           oninput: function (e) {
-            Scene.current.name = e.target.value
+            Scene.currentScene.name = e.target.value
           },
-          value: Scene.current.name ? Scene.current.name : `Scene ${Scene.current.id}`
+          value: Scene.currentScene.name ? Scene.currentScene.name : `Scene ${Scene.currentScene.id}`
         }),
         m('h2', `Start`),
         m("input.new-start-input[type=text]", {
           oninput: function (e) {
-            Scene.current.start = e.target.value
+            Scene.currentScene.start = e.target.value
           },
-          value: Scene.current.start ? Scene.current.start : ``
+          value: Scene.currentScene.start ? Scene.currentScene.start : ``
         }),
         m('h5', ``),
         m("button.save-changes-button[type=submit]", 'Save all changes'),
       ]),
       m('button.add-caption', {
         onclick: function() {
-          Scene.current.captions.push({
-            id : Scene.current.captions.length + 1
+          Scene.currentScene.captions.push({
+            id : Scene.currentScene.captions.length + 1
           })
           Scene.saveCaptions()
         }
       }, 'New Caption'),
       m('h2', 'List of captions'),
       m('.caption-list', captions.map(function(caption) {
-        return m(m.route.Link, {
-          class: 'caption-list-item',
-          href: `/scenes/scene-${vnode.attrs.id}/caption-${caption.id}`,
-        }, `Caption ${caption.id}`)
+
+        return m('div.caption-list-item', {key: caption.id}, [
+          m('a', {
+            onclick: function() {
+              m.route.set(`/scenes/scene-${vnode.attrs.id}/caption-${caption.id}`)
+            }
+          }, caption.name ? caption.name : `Caption ${caption.id}`),
+          m('button.delete-caption-button', {
+            onclick: function() {
+              //ask the user for confirmation.
+              if (confirm("Are you sure?")) {
+                Scene.deleteCaption(caption.id)
+              }
+            }
+          }, 'Delete')
+        ])
       })),
     ])
   }

--- a/src/client/src/views/SceneForm.js
+++ b/src/client/src/views/SceneForm.js
@@ -5,7 +5,9 @@ const Scene = require('../models/Scene')
 
 module.exports = {
   // on initialization of this component, set the current scene to the corresponding "current scene"
-  oninit: function(vnode) {Scene.setCurrent(vnode.attrs.id - 1)},
+  oninit: function(vnode) {
+    Scene.setCurrentScene(vnode.attrs.id - 1)
+  },
   view: function(vnode) {
     const captions = Scene.current.captions
 
@@ -49,7 +51,7 @@ module.exports = {
       m('.caption-list', captions.map(function(caption) {
         return m(m.route.Link, {
           class: 'caption-list-item',
-          href: `/edit-caption/${caption.id}`,
+          href: `/scenes/scene-${vnode.attrs.id}/caption-${caption.id}`,
         }, `Caption ${caption.id}`)
       })),
     ])

--- a/src/client/src/views/SceneForm.js
+++ b/src/client/src/views/SceneForm.js
@@ -6,7 +6,7 @@ const Scene = require('../models/Scene')
 module.exports = {
   // on initialization of this component, set the current scene to the corresponding "current scene"
   oninit: function(vnode) {
-    Scene.setCurrentScene(vnode.attrs.id - 1)
+    Scene.setCurrentScene(vnode.attrs.sceneId - 1)
   },
   view: function(vnode) {
     const captions = Scene.currentScene.captions
@@ -53,7 +53,7 @@ module.exports = {
         return m('div.caption-list-item', {key: caption.id}, [
           m('a', {
             onclick: function() {
-              m.route.set(`/scenes/scene-${vnode.attrs.id}/caption-${caption.id}`)
+              m.route.set(`/scenes/scene-${vnode.attrs.sceneId}/caption-${caption.id}`)
             }
           }, caption.name ? caption.name : `Caption ${caption.id}`),
           m('button.delete-caption-button', {

--- a/src/client/src/views/Scenes.js
+++ b/src/client/src/views/Scenes.js
@@ -15,7 +15,7 @@ module.exports = {
       m('h2', 'List of scenes'),
       m('.scene-list', Scene.getScenes()
         .map(function(scene) {
-          return m('div.scene-list-item', [
+          return m('div.scene-list-item', {key: scene.id}, [
             m('a', {
               onclick: function() {
                 m.route.set(`/scenes/scene-${scene.id}`)

--- a/src/client/src/views/Scenes.js
+++ b/src/client/src/views/Scenes.js
@@ -18,7 +18,7 @@ module.exports = {
           return m('div.scene-list-item', [
             m('a', {
               onclick: function() {
-                m.route.set(`/edit-scene/${scene.id}`)
+                m.route.set(`/scenes/scene-${scene.id}`)
               }
             }, scene.name ? scene.name : `Scene ${scene.id}`),
             // when maping the scenes the delete button is included.

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -27,7 +27,7 @@ a:hover {
   cursor: pointer;
 }
 
-.delete-scene-button {
+.delete-scene-button, .delete-caption-button {
   margin-left: 2em;
 }
 


### PR DESCRIPTION
Lots of changes here. Sorry for not breaking this into multiple branches with multiple PRs.

I did break things into multiple commits though.

The main things are:

added ability to rename captions.
added text input to caption form, so now a text string can be entered and saved for a caption.
added delete buttons for caption
minor styling tweaks
minor refactor of the url/route structure (this was necessary to make the caption editor page work) 