### PR TITLE
Per 209 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# data that Perception generates
+src/server/data.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -33,3 +33,43 @@ The `bin` direcetory contains the compiled "bundle" file.
 `src/views` contains the various views/screens.
 
 `src/tests` contains the test files.
+
+## Other stuff
+
+It useful to test out POST requests to the server using curl before implementing the code in the frontend.
+
+Here is an example curl command which takes in a JSON file:
+
+```
+curl -vX POST http://127.0.0.1:5000/submit -d @temp.json \
+--header "Content-Type: application/json"
+```
+
+Where temp.json in this case is a file formatted like so:
+
+```
+{
+  "caption_format": "CEA_608",
+  "scenes_list": [
+    {
+      "scene_id": 1,
+      "start_time": 123,
+      "background_color": "blue",
+      "position": "blah",
+      "opacity": "sure",
+      "caption_list": [
+        {
+          "caption_id": 1337,
+          "string_list": ["hello", "world"],
+          "color": "magenta",
+          "text_alignment": "right",
+          "underline": "nope",
+          "italics": "sure"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Just change `temp.json` to whatever file you want to point it to.

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -225,26 +225,29 @@ const Scene = {
       // TODO: once the server no longer requires everything, get rid of these hardcoded default values
       return {
         scene_id: scene.id,
-        start_time: scene.start ? Number(scene.start) : 123,
-        background_color: scene.background_color ? scene.background_color : 'blue',
-        position: scene.position ? scene.position : 'blah',
-        opacity: scene.opacity ? scene.opacity : 'sure',
+        scene_name: scene.name,
+        start: scene.start ? {time: Number(scene.start)} : {time: 0},
+        position: scene.position ? scene.position : {channel: '11'},
         caption_list: scene.captions.map(function(caption) {
           return {
             caption_id: caption.id,
-            string_list: caption.text ? [caption.text] : ['Huckleberry'],
-            color: caption.color ? caption.color : 'magenta',
-            text_alignment: caption.text_alignment ? caption.text_alignment : 'right',
-            underline: caption.underline ? caption.underline : 'nope',
-            italics: caption.italics ? caption.italics : 'sure'
+            caption_name: caption.name,
+            caption_string: caption.text ? caption.text : '',
+            background_color: caption.background_color ? caption.background_color : {color: 'black'},
+            fore_color: caption.fore_color ? caption.fore_color : {color: 'white'},
+            text_alignment: caption.text_alignment ? caption.text_alignment : {placement: 'left'},
+            underline: caption.underline ? caption.underline : false,
+            italics: caption.italics ? caption.italics : false,
+            opacity: caption.opacity ? caption.opacity : 100,
           }
         })
       }
     })
 
     return {
+      file_name: 'test_file',
       caption_format: caption_format,
-      scenes_list: scenes
+      scene_list: scenes
     }
   }
 }

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -226,19 +226,19 @@ const Scene = {
       return {
         scene_id: scene.id,
         scene_name: scene.name,
-        start: scene.start ? {time: Number(scene.start)} : {time: 0},
-        position: scene.position ? scene.position : {channel: '11'},
+        start: scene.start,
+        position: scene.position,
         caption_list: scene.captions.map(function(caption) {
           return {
             caption_id: caption.id,
             caption_name: caption.name,
-            caption_string: caption.text ? caption.text : '',
-            background_color: caption.background_color ? caption.background_color : {color: 'black'},
-            fore_color: caption.fore_color ? caption.fore_color : {color: 'white'},
-            text_alignment: caption.text_alignment ? caption.text_alignment : {placement: 'left'},
-            underline: caption.underline ? caption.underline : false,
-            italics: caption.italics ? caption.italics : false,
-            opacity: caption.opacity ? caption.opacity : 100,
+            caption_string: caption.text,
+            background_color: caption.background_color,
+            foreground_color: caption.foreground_color,
+            text_alignment: caption.text_alignment,
+            underline: caption.underline,
+            italics: caption.italics,
+            opacity: caption.opacity,
           }
         })
       }

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -1,3 +1,5 @@
+const m = require('mithril')
+
 // This object represents the list of scenes which will be displayed on the scenes page and exported via HTTP to the server.
 // Basically, this is our key "JSON object"
 // We use localStorage for persistence
@@ -161,9 +163,7 @@ const Scene = {
   },
 
   setInputFormat: function(format) {
-    const object = JSON.parse(localStorage.getItem('input-format'))
-    object['input-format'] = format
-    localStorage.setItem('input-format', JSON.stringify(object))
+    localStorage.setItem('input-format', JSON.stringify(format))
   },
 
   getInputFormat: function() {
@@ -204,7 +204,51 @@ const Scene = {
     
     //TODO Load each item into local storage.
     return true
+  },
+  
+  exportToServer: function() {
+    const payload = Scene.constructJSON()
+
+    return m.request({
+      method: 'POST',
+      url: '/submit',
+      body: payload
+    })
+  },
+
+  // this function constructs the JSON payload in the format the server expects
+  constructJSON: function() {
+    const caption_format = Scene.getInputFormat()
+    const scenes = Scene.getScenes().map(function(scene) {
+
+      // using defualt values on these since the server requires non-null and non-undefined values at this time.
+      // TODO: once the server no longer requires everything, get rid of these hardcoded default values
+      return {
+        scene_id: scene.id,
+        start_time: scene.start ? Number(scene.start) : 123,
+        background_color: scene.background_color ? scene.background_color : 'blue',
+        position: scene.position ? scene.position : 'blah',
+        opacity: scene.opacity ? scene.opacity : 'sure',
+        caption_list: scene.captions.map(function(caption) {
+          return {
+            caption_id: caption.id,
+            string_list: caption.text ? [caption.text] : ['Huckleberry'],
+            color: caption.color ? caption.color : 'magenta',
+            text_alignment: caption.text_alignment ? caption.text_alignment : 'right',
+            underline: caption.underline ? caption.underline : 'nope',
+            italics: caption.italics ? caption.italics : 'sure'
+          }
+        })
+      }
+    })
+
+    return {
+      caption_format: caption_format,
+      scenes_list: scenes
+    }
   }
 }
+
+
 
 module.exports = Scene

--- a/src/client/src/tests/Start.js
+++ b/src/client/src/tests/Start.js
@@ -20,13 +20,13 @@ o.spec('Start', function(){
         // When trigger select box and choose Teletext option, the option should
         // correctly saved into local storage
         out.trigger('select.language-input', 'onchange', {target: {value: "Teletext"}})
-        var object = Scene.getInputFormat()
-        o(object['input-format'] === 'Teletext').equals(true)
+        var format = Scene.getInputFormat()
+        o(format === 'Teletext').equals(true)
 
         // When trigger select box and choose CEA-608 option, local storage
         // should no longer contain Teletext option
         out.trigger('select.language-input', 'onchange', {target: {value: "CEA-608"}})
-        var object = Scene.getInputFormat()
-        o(object['input-format'] === 'Teletext').equals(false)
+        var format = Scene.getInputFormat()
+        o(format === 'Teletext').equals(false)
     })
 })

--- a/src/client/src/views/Scenes.js
+++ b/src/client/src/views/Scenes.js
@@ -12,6 +12,18 @@ module.exports = {
       m('button.add-scene', {
         onclick: Scene.addScene
       }, 'New Scene'),
+      m('button.export', {
+        onclick: function() {
+          Scene.exportToServer()
+            .then(function(response) {
+              alert('Successfully exported!')
+            })
+            .catch(function(e) {
+              alert(`Error: response code ${e.code}, ${e.response.Error}`)
+              console.dir(e)
+            })
+        }
+      }, 'Export'),
       m('h2', 'List of scenes'),
       m('.scene-list', Scene.getScenes()
         .map(function(scene) {

--- a/src/client/src/views/Start.js
+++ b/src/client/src/views/Start.js
@@ -19,11 +19,11 @@ module.exports = {
           selected: "selected",
           disabled: "disabled"
         }, 'Select your option'),
-        ["CEA-608", "Teletext"].map(function(opt) {
-          var object = Scene.getInputFormat()
+        ["CEA_608", "Teletext"].map(function(opt) {
+          const format = Scene.getInputFormat()
           return m('option', {
             value: opt,
-            selected: opt === object['input-format'] ? true : false
+            selected: opt === format ? true : false
           }, opt)
         }) 
       ]),

--- a/src/client/src/views/Start.js
+++ b/src/client/src/views/Start.js
@@ -19,7 +19,7 @@ module.exports = {
           selected: "selected",
           disabled: "disabled"
         }, 'Select your option'),
-        ["CEA_608", "Teletext"].map(function(opt) {
+        ["CEA-608", "Teletext"].map(function(opt) {
           const format = Scene.getInputFormat()
           return m('option', {
             value: opt,

--- a/src/server/cea_608_encoder/byte_pair_generator.py
+++ b/src/server/cea_608_encoder/byte_pair_generator.py
@@ -86,7 +86,7 @@ def consume_captions(caption_list: list) -> dict:
 
         caption_string_byte_pairs = []
         for string in caption['string_list']:
-            caption_string_byte_pairs.append(utils.create_byte_pairs_for_caption_string(string))
+            caption_string_byte_pairs.append(utils.create_byte_pairs_for_caption_string(string, 0))
 
         if caption['color']:
             caption_color = caption['color']


### PR DESCRIPTION
This is the same as PER-209 (PR 23: https://github.com/capstone-team-a/Perception/pull/23) except that it has rebased from develop and also it uses the latest JSON schema when sending the payload in the post request.

The reason I didn't update the other PR, and instead created a new one, is because I rebased from master which means if I would have forced pushed it would have changed history. Also, I like the idea of keeping the older one up (since it worked) and this one does not work since it requires the backend be updated. 

The backend will need to update the post request endpoint to reflect these changes.

So if we can get the backend updated, this PR should be merged in as well.

If we don't get the backend updated in time for our demo, merge in PR 23: https://github.com/capstone-team-a/Perception/pull/23 instead of this one.