### PR TITLE
Form builder abstraction

### DIFF
--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -387,7 +387,7 @@ const Scene = {
       id: loadedCaption['caption_id'],
       name: caption_name,
       text: caption_string,
-      background: background_color,
+      background_color: background_color,
       foreground_color: foreground_color,
       alignment: text_alignment,
       underline: underline,

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -175,24 +175,6 @@ const Scene = {
     })
   },
 
-  // saves the current caption with its new name to localStorage
-  saveCaptionName: function() {
-    const list = Scene.getScenes()
-
-    list[Scene.findSceneIndex(Scene.currentScene.id)].captions[Scene.findCaptionIndex(Scene.currentCaption.id)].name = Scene.currentCaption.name
-
-    Scene.setScenes(list)
-  },
-
-  // saves the current caption with its new text to localStorage
-  saveCaptionText: function() {
-    const list = Scene.getScenes()
-
-    list[Scene.findSceneIndex(Scene.currentScene.id)].captions[Scene.findCaptionIndex(Scene.currentCaption.id)].text = Scene.currentCaption.text
-
-    Scene.setScenes(list)
-  },
-
   deleteCaption: function(captionId) {
     // look for the caption
     const indexToRemove = Scene.currentScene.captions.findIndex(function(caption) {
@@ -368,22 +350,17 @@ const Scene = {
     return URL.createObjectURL(blob)
   },
 
+  // generic save function for saving an attribute without any custom validation
   // this is used to save a variable attribute so you don't have to know what attribute you are trying to save.
   // currently it is used by the formBuilder so it can call the correct save function for each attribute.
   saveCaptionAttr: function (attr) {
-    const attrToSaveFn = {
-      'name': Scene.saveCaptionName,
-      'text': Scene.saveCaptionText,
-    }
+    const list = Scene.getScenes()
 
-    if (!attrToSaveFn[attr]) {
-      console.log(`No save function found for attribute: ${attr}`)
-    }
+    list[Scene.findSceneIndex(Scene.currentScene.id)].captions[Scene.findCaptionIndex(Scene.currentCaption.id)][attr] = Scene.currentCaption[attr]
 
-    return attrToSaveFn[attr]()
+    Scene.setScenes(list)
   },
 }
-
 
 
 module.exports = Scene

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -366,7 +366,22 @@ const Scene = {
     const blob = new Blob([JSON.stringify(Scene.constructJSON())], {type : 'application/json'})
 
     return URL.createObjectURL(blob)
-  }
+  },
+
+  // this is used to save a variable attribute so you don't have to know what attribute you are trying to save.
+  // currently it is used by the formBuilder so it can call the correct save function for each attribute.
+  saveCaptionAttr: function (attr) {
+    const attrToSaveFn = {
+      'name': Scene.saveCaptionName,
+      'text': Scene.saveCaptionText,
+    }
+
+    if (!attrToSaveFn[attr]) {
+      console.log(`No save function found for attribute: ${attr}`)
+    }
+
+    return attrToSaveFn[attr]()
+  },
 }
 
 

--- a/src/client/src/tests/CaptionForm.js
+++ b/src/client/src/tests/CaptionForm.js
@@ -24,7 +24,7 @@ o.spec('CaptionForm', function() {
     o(out.should.contain('Caption 1')).equals(true)
 
     // make sure that change name form changes the name in the view
-    out.setValue('.new-name-input', 'new name') // trigger an input in the input form
+    out.setValue('.name-input', 'new name') // trigger an input in the input form
     o(out.should.not.contain('Caption 1')).equals(true)
     o(out.should.contain('new name')).equals(true)
 
@@ -33,7 +33,7 @@ o.spec('CaptionForm', function() {
     o(Scene.currentScene.captions.find(caption => caption.name === 'new name') !== undefined).equals(true)
 
     // make sure that the text input changes the text
-    out.setValue('.new-caption-text-input', 'hello') // trigger an input in the input form
+    out.setValue('.text-input', 'hello') // trigger an input in the input form
     out.trigger('.save-changes-form', 'onsubmit', {preventDefault: () => {}}) // trigger a submit event on the form
     o(Scene.currentScene.captions.find(caption => caption.text === 'hello') !== undefined).equals(true)
 

--- a/src/client/src/utils/captionFormSchema.js
+++ b/src/client/src/utils/captionFormSchema.js
@@ -2,10 +2,12 @@
 
 // each key in the schema represents an attribute
 // each value in the schema is an object that contains:
-//     1. A list of options for that attribute, if any. (for dropdowns, checkboxes, etc.)
-//     2. The label name of that attribute
+//     1. A list of options for that attribute, if any. (for dropdowns)
+//         These are the options that the user is to select from.
+//     2. The label name of that attribute. This is the label that will show up in the UI. It describes what the attribute is.
 //     3. The type of the input. (dropdown, checkbox, text, etc.)
-
+//     4. Optionally, a custom save function (for example to have custom validation logic).
+//         This property should be called customSaveFn.
 
 module.exports = {
   'name': {
@@ -24,5 +26,11 @@ module.exports = {
     label: 'Background Color',
     type: 'dropdown',
     options: ['White', 'Green', 'Blue', 'Cyan', 'Red', 'Yellow', 'Magenta', 'Black']
+  },
+
+  'underline': {
+    label: 'Underline',
+    type: 'checkbox',
+    options: null
   }
 }

--- a/src/client/src/utils/captionFormSchema.js
+++ b/src/client/src/utils/captionFormSchema.js
@@ -1,0 +1,22 @@
+// this schema is used by formBuilder to create forms in a declarative way.
+
+// each key in the schema represents an attribute
+// each value in the schema is an object that contains:
+//     1. A list of options for that attribute, if any. (for dropdowns, checkboxes, etc.)
+//     2. The label name of that attribute
+//     3. The type of the input. (dropdown, checkbox, text, etc.)
+
+
+module.exports = {
+  'name': {
+    label: 'Caption Name',
+    type: 'text',
+    options: null
+  },
+
+  'text': {
+    label: 'Caption String',
+    type: 'text',
+    options: null
+  }
+}

--- a/src/client/src/utils/captionFormSchema.js
+++ b/src/client/src/utils/captionFormSchema.js
@@ -18,5 +18,11 @@ module.exports = {
     label: 'Caption String',
     type: 'text',
     options: null
+  },
+
+  'background_color': {
+    label: 'Background Color',
+    type: 'dropdown',
+    options: ['White', 'Green', 'Blue', 'Cyan', 'Red', 'Yellow', 'Magenta', 'Black']
   }
 }

--- a/src/client/src/utils/formBuilder.js
+++ b/src/client/src/utils/formBuilder.js
@@ -1,4 +1,5 @@
 const m = require('mithril')
+const Scene = require('../models/Scene')
 
 function formBuilder(schema) {
   // each key in the schema represents an attribute
@@ -38,7 +39,7 @@ function formBuilder(schema) {
       e.preventDefault()
       // call the save function for each attribute
       attributes.forEach(attr => {
-        Scene.saveCaptionAttr[attr]()
+        Scene.saveCaptionAttr(attr)
       })
     }
   }, [
@@ -46,3 +47,5 @@ function formBuilder(schema) {
     m("button.save-changes-button[type=submit]", 'Save all changes'),
   ])
 }
+
+module.exports = formBuilder

--- a/src/client/src/utils/formBuilder.js
+++ b/src/client/src/utils/formBuilder.js
@@ -19,15 +19,22 @@ function formBuilder(schema) {
   })
 
   const labelsAndInputs = attributeAndOptions.map(item => {
+
+    const inputOptions = {
+      id: `${item.attr}-input`,
+      oninput: e => {
+        Scene.currentCaption[item.attr] = e.target.value
+      },
+      value: Scene.currentCaption[item.attr] ? Scene.currentCaption[item.attr] : ''
+    }
+    
     return [
       m('label', {for: `${item.attr}-input`}, item.label),
-      m(`input.${item.attr}-input[type=${item.type}]`, {
-        id: `${item.attr}-input`,
-        oninput: e => {
-          Scene.currentCaption[item.attr] = e.target.value
-        },
-        value: Scene.currentCaption[item.attr] ? Scene.currentCaption[item.attr] : ''
-      })
+      item.type === 'text'
+        ? m(`input.${item.attr}-input[type=${item.type}]`, inputOptions)
+        : item.type === 'dropdown'
+        ? m('select', inputOptions, item.options.map(option => m('option', option)))
+        : null
     ]
   })
 
@@ -38,8 +45,12 @@ function formBuilder(schema) {
     onsubmit: e => {
       e.preventDefault()
       // call the save function for each attribute
-      attributes.forEach(attr => {
-        Scene.saveCaptionAttr(attr)
+      attributeAndOptions.forEach(item => {
+        if (item.customSaveFn) {
+          item.customSaveFn()
+        } else {
+          Scene.saveCaptionAttr(item.attr) 
+        }
       })
     }
   }, [

--- a/src/client/src/utils/formBuilder.js
+++ b/src/client/src/utils/formBuilder.js
@@ -23,14 +23,15 @@ function formBuilder(schema) {
     const inputOptions = {
       id: `${item.attr}-input`,
       oninput: e => {
-        Scene.currentCaption[item.attr] = e.target.value
+        Scene.currentCaption[item.attr] = item.type === 'checkbox' ? e.target.checked : e.target.value
       },
-      value: Scene.currentCaption[item.attr] ? Scene.currentCaption[item.attr] : ''
+      value: Scene.currentCaption[item.attr] ? Scene.currentCaption[item.attr] : '',
+      checked: Scene.currentCaption[item.attr]
     }
     
     return [
       m('label', {for: `${item.attr}-input`}, item.label),
-      item.type === 'text'
+      item.type === 'text' || item.type === 'checkbox'
         ? m(`input.${item.attr}-input[type=${item.type}]`, inputOptions)
         : item.type === 'dropdown'
         ? m('select', inputOptions, item.options.map(option => m('option', option)))

--- a/src/client/src/utils/formBuilder.js
+++ b/src/client/src/utils/formBuilder.js
@@ -1,0 +1,48 @@
+const m = require('mithril')
+
+function formBuilder(schema) {
+  // each key in the schema represents an attribute
+  // each value in the schema is an object that contains:
+  //     1. A list of options for that attribute, if any. (for dropdowns, checkboxes, etc.)
+  //     2. The label name of that attribute
+  //     3. The type of the input. (dropdown, checkbox, text, etc.)
+
+  const attributes = Object.keys(schema)
+  const attributeAndOptions = attributes.map(attribute => {
+    return {
+      attr: attribute,
+      options: schema[attribute].options,
+      label: schema[attribute].label,
+      type: schema[attribute].type
+    }
+  })
+
+  const labelsAndInputs = attributeAndOptions.map(item => {
+    return [
+      m('label', {for: `${item.attr}-input`}, item.label),
+      m(`input.${item.attr}-input[type=${item.type}]`, {
+        id: `${item.attr}-input`,
+        oninput: e => {
+          Scene.currentCaption[item.attr] = e.target.value
+        },
+        value: Scene.currentCaption[item.attr] ? Scene.currentCaption[item.attr] : ''
+      })
+    ]
+  })
+
+  // flatten the array-of-arrays into just 1 array
+  const formItems = Array.prototype.concat.apply([], labelsAndInputs)
+
+  return m('form.save-changes-form', {
+    onsubmit: e => {
+      e.preventDefault()
+      // call the save function for each attribute
+      attributes.forEach(attr => {
+        Scene.saveCaptionAttr[attr]()
+      })
+    }
+  }, [
+    ...formItems,
+    m("button.save-changes-button[type=submit]", 'Save all changes'),
+  ])
+}

--- a/src/client/src/views/CaptionForm.js
+++ b/src/client/src/views/CaptionForm.js
@@ -2,6 +2,8 @@
 
 const m = require('mithril')
 const Scene = require('../models/Scene')
+const schema = require('../utils/captionFormSchema')
+const formBuilder = require('../utils/formBuilder')
 
 module.exports = {
   oninit: function(vnode) {
@@ -26,35 +28,7 @@ module.exports = {
         href: `/scenes/scene-${Scene.currentScene.id}`,
       }, 'Back To Scene'),
       m('h1', Scene.currentCaption.name ? Scene.currentCaption.name : `Caption ${Scene.currentCaption.id}`),
-      m('form.save-changes-form', {
-        onsubmit: function(e) {
-          e.preventDefault()
-          Scene.saveCaptionName()
-          Scene.saveCaptionText()
-        }
-      }, [
-        m('label', {
-          for: 'new-name-input'
-        }, 'Caption Name'),
-        m("input.new-name-input[type=text]", {
-          id: 'new-name-input',
-          oninput: function (e) {
-            Scene.currentCaption.name = e.target.value
-          },
-            value: Scene.currentCaption.name ? Scene.currentCaption.name : ''
-        }),
-        m('label', {
-          for: 'new-caption-text-input'
-        }, 'Caption String'),
-        m("input.new-caption-text-input[type=text]", {
-          id: 'new-caption-text-input',
-          oninput: function (e) {
-            Scene.currentCaption.text = e.target.value
-          },
-          value: Scene.currentCaption.text ? Scene.currentCaption.text : ``
-        }),
-        m("button.save-changes-button[type=submit]", 'Save all changes'),
-      ])
+      formBuilder(schema),
     ])
   }
 }


### PR DESCRIPTION
This feature allows anyone to easily add new caption form inputs into the caption form page.

To add a new form, simply edit the captionFormSchema file by adding your desired attribute along with its type, label, options, and an optional custom save function.

Examples have been created for text inputs, dropdowns and checkboxes.

The old caption form code has been refactored to use the formBuilder.