### PR TITLE
Per 222 - append scenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # data that Perception generates
 src/server/data.json
+data
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -448,6 +448,10 @@ const Scene = {
         return cb(err)
       }
 
+      if (fileData.caption_format !== Scene.getInputFormat()) {
+        return cb(`Caption format of file (${fileData.caption_format}) doesn't match expected format (${Scene.getInputFormat()})`)
+      }
+
       if (!fileData.scene_list || !Array.isArray(fileData.scene_list)) {
         return cb(`File doesn't contain a valid 'scene_list'.`)
       }

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -468,6 +468,7 @@ const Scene = {
     // add new scene object
     scene_list.push({
       id: Scene.uniqueSceneId(),
+      name: scene.scene_name,
       start: null,
       captions: scene.caption_list.map(caption => {
         return Scene.load608CaptionFromFile(caption)

--- a/src/client/src/models/Scene.js
+++ b/src/client/src/models/Scene.js
@@ -47,24 +47,30 @@ const Scene = {
   addScene: function() {
     // get current list
     const scene_list = Scene.getScenes()
-      // keeps tracks of id numbers in order to not crash into each other
-    var scene_max_id = 0
-    // Finds the max scene id in the list
-    if (scene_list.length > 0) {
-      for (i = 0; i < scene_list.length; i++) {
-        if (scene_max_id < scene_list[i].id) {
-          scene_max_id = scene_list[i].id
-        }
-      }
-    }
+   
     // add new scene object
     scene_list.push({
-      id: scene_max_id + 1,
+      id: Scene.uniqueSceneId(),
       start: null,
       captions: []
     })
     // saves the current list
     Scene.setScenes(scene_list)
+  },
+
+  uniqueSceneId: function() {
+    const scene_list = Scene.getScenes()
+    let scene_max_id = 0
+    // Finds the max scene id in the list
+    if (scene_list.length > 0) {
+      for (let i = 0; i < scene_list.length; i++) {
+        if (scene_max_id < scene_list[i].id) {
+          scene_max_id = scene_list[i].id
+        }
+      }
+    }
+
+    return scene_max_id + 1
   },
 
   deleteScene: function(sceneid) {
@@ -413,6 +419,63 @@ const Scene = {
 
     Scene.setScenes(list)
   },
+
+  loadFile: function(file, cb) {
+    if(!Scene.jsonExtensionCheck(file.name)) {
+      return cb("File type to load from must be .json")
+    }
+
+      const reader = new FileReader()
+      const blob = file.slice(0, file.size)
+      reader.onload = function(e) {
+		try {
+          const fileData = JSON.parse(e.target.result)
+          return cb(null, fileData)
+        } catch (error) {
+          return cb("JSON file was malformed.\n" + error)
+        }
+      }
+      reader.onerror = function(e) {
+        return cb("There was an error while reading your file.")
+      }
+      
+      reader.readAsText(blob)
+  },
+
+  appendFromFile: function(file, cb) {
+    Scene.loadFile(file, (err, fileData) => {
+      if (err) {
+        return cb(err)
+      }
+
+      if (!fileData.scene_list || !Array.isArray(fileData.scene_list)) {
+        return cb(`File doesn't contain a valid 'scene_list'.`)
+      }
+
+      const newScenes = fileData.scene_list.forEach(scene => {
+        Scene.appendScene(scene)
+      })
+
+      return cb(null)
+    })
+  },
+
+  // similar to addScene, except this function takes in scene data instead of creating an empty scene.
+  // This funciton is used in the appendFromFile function.
+  appendScene: function(scene) {
+    const scene_list = Scene.getScenes()
+   
+    // add new scene object
+    scene_list.push({
+      id: Scene.uniqueSceneId(),
+      start: null,
+      captions: scene.caption_list.map(caption => {
+        return Scene.load608CaptionFromFile(caption)
+      })
+    })
+    // saves the current list
+    Scene.setScenes(scene_list)
+  }
 }
 
 

--- a/src/client/src/views/Scenes.js
+++ b/src/client/src/views/Scenes.js
@@ -40,6 +40,9 @@ module.exports = {
                 alert(err)
               } else {
                 alert('Successfully appended file data to scene list.')
+                // clear the input
+                document.getElementById('appendFile').value = ''
+                inputFile = null
                 // redraw the DOM so we can see the new scenes
                 m.redraw()
               }
@@ -51,7 +54,7 @@ module.exports = {
         m("label", {
             class: "file",
           },
-          m("input", {
+          m("input#appendFile", {
             onchange: function(e){
               inputFile = e.target.files[0]
             },

--- a/src/client/src/views/Scenes.js
+++ b/src/client/src/views/Scenes.js
@@ -28,6 +28,43 @@ module.exports = {
         download: 'scenes',
         href: Scene.getDownloadURL()
       }, 'Download JSON file'),
+
+      m('form.append-file-form', {
+        onsubmit: function(e) {
+          e.preventDefault()
+          if (!inputFile) {
+            alert("Must select file to load from")
+          } else {
+            Scene.appendFromFile(inputFile, err => {
+              if (err) {
+                alert(err)
+              } else {
+                alert('Successfully appended file data to scene list.')
+                // redraw the DOM so we can see the new scenes
+                m.redraw()
+              }
+            })
+          }
+        }
+      }, [
+        m('h3', 'Append Scenes From File'),
+        m("label", {
+            class: "file",
+          },
+          m("input", {
+            onchange: function(e){
+              inputFile = e.target.files[0]
+            },
+            accept: ".json",
+            type: "file",
+          }),
+          m("span", {
+            class: "file-custom",
+          })
+        ),
+        m('button.load-file[type=submit]', 'Load File'),
+      ]),
+      
       m('h2', 'List of scenes'),
       m('.scene-list', Scene.getScenes()
         .map(function(scene) {


### PR DESCRIPTION
Scene list page now has a file import form that will append a JSON file of scenes to the scene list.

Satisfies all the requirements outlined in the PER-222 card in trello as far as I can tell.

I also added the data files that the backend generates to the gitignore.

Also did some minor refactoring, for example I created a uniqueSceneId function so we don't repeat ourselves too much.

More refactoring could be done. For example, the start page has a file input for importing scene data. Some of that code was copied since it is similar functionality.