### PR TITLE
Saving exported file with name supplied by frontend

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -28,12 +28,12 @@ def submit():
 
     try:
         now = datetime.now()
-        date_time = now.strftime("%m.%d.%Y_%H-%M-%S")
-        file_name = caption_data["file_name"] + f'output_{date_time}.json'
+        time_stamp = now.strftime("%m.%d.%Y_%H-%M-%S")
+        file_name = caption_data["file_name"] + f'output_{time_stamp}.json'
 
         with open(path_to_schema_folder + file_name, 'w', encoding='utf-8') as file:
             json.dump(caption_data, file, ensure_ascii=False, indent=4)
-        consume(caption_data)
+        consume(caption_data,time_stamp)
         return Response(json.dumps({'Success': 'ok'}),
                         status=200,
                         mimetype='application/json')

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -27,10 +27,6 @@ def submit():
     caption_data = request.get_json()
 
     try:
-        #now = datetime.now()
-        #date_time = now.strftime("%m.%d.%Y_%H-%M-%S")
-        #file_name = f'output_{date_time}.json'
-
         file_name = caption_data["file_name"] + '.json'
 
         with open(path_to_schema_folder + file_name, 'w', encoding='utf-8') as file:

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -29,7 +29,7 @@ def submit():
     try:
         now = datetime.now()
         time_stamp = now.strftime("%m.%d.%Y_%H-%M-%S")
-        file_name = caption_data["file_name"] + f'output_{time_stamp}.json'
+        file_name = caption_data["file_name"] + f'_output_{time_stamp}.json'
 
         with open(path_to_schema_folder + file_name, 'w', encoding='utf-8') as file:
             json.dump(caption_data, file, ensure_ascii=False, indent=4)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -37,6 +37,12 @@ def submit():
         return Response(json.dumps({'Success': 'ok'}),
                         status=200,
                         mimetype='application/json')
+    except KeyError as err:
+        error_message = {'Error': 'No filename provided: {err}'}
+        app.logger.error(error_message)
+        return Response(json.dumps(error_message),
+                        status=500,
+                        mimetype='application/json')
     except IOError as err:
         error_message = {'Error': f'Writing JSON to file failed: {err}'}
         app.logger.error(error_message)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -27,7 +27,9 @@ def submit():
     caption_data = request.get_json()
 
     try:
-        file_name = caption_data["file_name"] + '.json'
+        now = datetime.now()
+        date_time = now.strftime("%m.%d.%Y_%H-%M-%S")
+        file_name = caption_data["file_name"] + f'output_{date_time}.json'
 
         with open(path_to_schema_folder + file_name, 'w', encoding='utf-8') as file:
             json.dump(caption_data, file, ensure_ascii=False, indent=4)

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -27,9 +27,11 @@ def submit():
     caption_data = request.get_json()
 
     try:
-        now = datetime.now()
-        date_time = now.strftime("%m.%d.%Y_%H-%M-%S")
-        file_name = f'output_{date_time}.json'
+        #now = datetime.now()
+        #date_time = now.strftime("%m.%d.%Y_%H-%M-%S")
+        #file_name = f'output_{date_time}.json'
+
+        file_name = caption_data["file_name"] + '.json'
 
         with open(path_to_schema_folder + file_name, 'w', encoding='utf-8') as file:
             json.dump(caption_data, file, ensure_ascii=False, indent=4)

--- a/src/server/cea_608_encoder/byte_pair_generator.py
+++ b/src/server/cea_608_encoder/byte_pair_generator.py
@@ -45,7 +45,7 @@ def consume(caption_data: dict, time_stamp: str):
 
     scene_data = caption_data['scene_list']
     caption_format = caption_data['caption_format']
-    file_name = caption_data['file_name'] + f'output_{time_stamp}.json'
+    file_name = caption_data['file_name'] + f'_output_{time_stamp}.json'
 
     caption_data = {
         'type': caption_format,

--- a/src/server/cea_608_encoder/byte_pair_generator.py
+++ b/src/server/cea_608_encoder/byte_pair_generator.py
@@ -13,10 +13,11 @@ supported_caption_formats = [
 ]
 
 
-def write_caption_data_to_file(caption_data: dict):
+def write_caption_data_to_file(caption_data: dict, file_name: str):
     """Writes caption data to file as json.
 
        :param caption_data: json with byte pairs
+       :param file_name: used for saving resulting file
     """
     # datetime object containing current date and time
     now = datetime.now()
@@ -24,7 +25,7 @@ def write_caption_data_to_file(caption_data: dict):
     dt_string = now.strftime("%m.%d.%Y_%H-%M-%S")
 
     path = config.path_to_data_folder
-    file_name = f'output_{dt_string}.json'
+    file_name = file_name + f'output_{dt_string}.json'
     try:
         with open(path + file_name, 'w', encoding='utf-8') as file:
             json.dump(caption_data, file, ensure_ascii=False, indent=4)
@@ -50,13 +51,14 @@ def consume(caption_data: dict):
 
     scene_data = caption_data['scene_list']
     caption_format = caption_data['caption_format']
+    file_name = caption_data['file_name']
 
     caption_data = {
         'type': caption_format,
         'scenes': consume_scenes(scene_data)
     }
 
-    write_caption_data_to_file(caption_data)
+    write_caption_data_to_file(caption_data,file_name)
 
 
 def consume_scenes(scene_list: list) -> list:

--- a/src/server/cea_608_encoder/byte_pair_generator.py
+++ b/src/server/cea_608_encoder/byte_pair_generator.py
@@ -19,13 +19,7 @@ def write_caption_data_to_file(caption_data: dict, file_name: str):
        :param caption_data: json with byte pairs
        :param file_name: used for saving resulting file
     """
-    # datetime object containing current date and time
-    now = datetime.now()
-    # mm.dd.YY_H:M:S
-    dt_string = now.strftime("%m.%d.%Y_%H-%M-%S")
-
     path = config.path_to_data_folder
-    file_name = file_name + f'output_{dt_string}.json'
     try:
         with open(path + file_name, 'w', encoding='utf-8') as file:
             json.dump(caption_data, file, ensure_ascii=False, indent=4)
@@ -33,7 +27,7 @@ def write_caption_data_to_file(caption_data: dict, file_name: str):
         logging.error(f'Could not write JSON to file: {err}')
 
 
-def consume(caption_data: dict):
+def consume(caption_data: dict, time_stamp: str):
     """Perform error handling around caption format and ensure
     there are scenes to create byte pairs for.
 
@@ -51,7 +45,7 @@ def consume(caption_data: dict):
 
     scene_data = caption_data['scene_list']
     caption_format = caption_data['caption_format']
-    file_name = caption_data['file_name']
+    file_name = caption_data['file_name'] + f'output_{time_stamp}.json'
 
     caption_data = {
         'type': caption_format,

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -22,7 +22,7 @@ def main():
     try:
         now = datetime.now()
         time_stamp = now.strftime("%m.%d.%Y_%H-%M-%S")
-        file_name = args.f + f'output_{time_stamp}.json'
+        file_name = args.f - '.json' + f'output_{time_stamp}.json'
         with open(args.file_path, 'r') as file:
             caption_data = json.load(file)
             consume(caption_data,file_name)

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+from datetime import datetime
 
 from src.server.cea_608_encoder.byte_pair_generator import consume
 
@@ -19,9 +20,12 @@ def main():
     args = parser.parse_args()
 
     try:
+        now = datetime.now()
+        time_stamp = now.strftime("%m.%d.%Y_%H-%M-%S")
+        file_name = args.f + f'output_{time_stamp}.json'
         with open(args.file_path, 'r') as file:
             caption_data = json.load(file)
-            consume(caption_data)
+            consume(caption_data,file_name)
        
     except IOError as err:
         logging.error('Error trying to read in the file.', exc_info=err)

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -22,10 +22,9 @@ def main():
     try:
         now = datetime.now()
         time_stamp = now.strftime("%m.%d.%Y_%H-%M-%S")
-        file_name = args.f - '.json' + f'output_{time_stamp}.json'
         with open(args.file_path, 'r') as file:
             caption_data = json.load(file)
-            consume(caption_data,file_name)
+            consume(caption_data,time_stamp)
        
     except IOError as err:
         logging.error('Error trying to read in the file.', exc_info=err)


### PR DESCRIPTION
This saves the schema file with the name supplied, but not the byte_pair output file. Let me know if I should also save the byte_pair file with the name given by frontend.